### PR TITLE
default to not showing error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Validate form inputs
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `data-validate-rules`       | A comma separated list of rules to use for validation. See validation rules below.                                                                                                     |
 | `data-validate-message`     | A custom error message instead of the default one. Use `%l` to add the input label to your element and `%p` to the validation property. For example if you use `minLength[8]` %p is 8. |
-| `data-validate-hide-errors` | Don't automatically show the validation error under the text box. You can handel them yourself this way.                                                                               |
+| `data-validate-show-errors` | Automatically create and show the validation error under the text box.                                                                                                                 |
 
 #### Validation rules
 

--- a/src/tests/delay.test.ts
+++ b/src/tests/delay.test.ts
@@ -8,16 +8,7 @@ describe('delay', () => {
 		const startTime = new Date();
 		await delay(time);
 		const totalTime = new Date().getTime() - startTime.getTime();
-		expect(totalTime).toBeGreaterThanOrEqual(time);
-		expect(totalTime).toBeLessThanOrEqual(time + 2);
-	});
-
-	it('should delay the call stack', async () => {
-		const time = 100;
-		const startTime = new Date();
-		await delay(time);
-		const totalTime = new Date().getTime() - startTime.getTime();
-		expect(totalTime).toBeGreaterThanOrEqual(time);
+		expect(totalTime).toBeGreaterThanOrEqual(time - 2);
 		expect(totalTime).toBeLessThanOrEqual(time + 2);
 	});
 });

--- a/src/tests/validate.test.ts
+++ b/src/tests/validate.test.ts
@@ -219,10 +219,11 @@ describe('Validator', () => {
 			input.id = item.id;
 			input.name = input.id;
 			input.setAttribute('data-validate-rules', item.rule);
+			input.setAttribute('data-validate-show-errors', 'true');
 			input.setAttribute('class', `validate-test`);
 			p.appendChild(input);
 			inputForm.appendChild(p);
-			// console.log('\n', p.innerHTML);
+			console.log('\n', p.innerHTML);
 		}
 
 		const checkRadioForm = document.getElementById(
@@ -431,6 +432,7 @@ describe('Validator', () => {
 		expect(input).toBeDefined();
 		input.value = '';
 		input.setAttribute('data-validate-message', customMessage);
+		input.setAttribute('data-show-message', customMessage);
 		const errors = validate(input);
 		expect(errors.length).toBe(1);
 		expect(errors[0].error).toBe(customMessage.replace('%l', 'required'));

--- a/src/tests/validate.test.ts
+++ b/src/tests/validate.test.ts
@@ -223,7 +223,7 @@ describe('Validator', () => {
 			input.setAttribute('class', `validate-test`);
 			p.appendChild(input);
 			inputForm.appendChild(p);
-			console.log('\n', p.innerHTML);
+			// console.log('\n', p.innerHTML);
 		}
 
 		const checkRadioForm = document.getElementById(

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -459,7 +459,7 @@ export function validateAll(inputs: InputCollection): ValidatorError[] {
  *   name="email"
  *   data-validate-rules='require,email'
  *   data-validate-message="My custom validation message (or just use the default)"
- *   data-validate-hide-errors />
+ *   data-validate-show-errors />
  */
 export default function validate(
 	input: FormInput | null | undefined
@@ -470,10 +470,11 @@ export default function validate(
 		return validateAll(null);
 	}
 
-	const showErrors = Object.prototype.hasOwnProperty.call(
-		input.dataset,
-		'validateShowErrors'
-	);
+	const showErrors =
+		Object.prototype.hasOwnProperty.call(
+			input.dataset,
+			'validateShowErrors'
+		) && input.dataset.validateShowErrors !== 'false';
 
 	if (showErrors) {
 		removeAllValidationErrors();

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -470,13 +470,12 @@ export default function validate(
 		return validateAll(null);
 	}
 
-	const hideErrors =
-		Object.prototype.hasOwnProperty.call(
-			input.dataset,
-			'validateHideErrors'
-		) && input.dataset.validateHideErrors !== 'false';
+	const showErrors = Object.prototype.hasOwnProperty.call(
+		input.dataset,
+		'validateShowErrors'
+	);
 
-	if (!hideErrors) {
+	if (showErrors) {
 		removeAllValidationErrors();
 	}
 
@@ -521,7 +520,7 @@ export default function validate(
 		}
 	}
 
-	if (!hideErrors && errors.length) {
+	if (showErrors && errors.length) {
 		renderValidationError(input, errors[0]);
 	}
 


### PR DESCRIPTION
changed attribute from `data-validate-hide-errors` to `data-validate-show-errors` so that the validator defaults to not creating error labels. 
